### PR TITLE
Fix md metadata parse

### DIFF
--- a/app/javascript/components/shared/viewers/MarkdownViewer.vue
+++ b/app/javascript/components/shared/viewers/MarkdownViewer.vue
@@ -22,9 +22,13 @@
 
   const markdownContent = ref('')
 
-  const { _metadata, content } = parseMD(props.content)
-
-  markdownContent.value = props.setDefaultText ? (content.trim() || defaultText) : content
+  try {
+    const { _metadata, content } = parseMD(props.content)
+    markdownContent.value = props.setDefaultText ? (content.trim() || defaultText) : content
+  } catch (error) {
+    console.error(error)
+    markdownContent.value = props.content
+  }
 
   const anchorOptions = {
     tabIndex: false,


### PR DESCRIPTION
为 markdown 文件解析过程添加错误处理，在解析出错的情况下将原文档作为输入，避免出现页面出错的情况。