### PR TITLE
add missing route rule in nginx.conf

### DIFF
--- a/script/all_in_one/nginx/nginx.conf
+++ b/script/all_in_one/nginx/nginx.conf
@@ -103,12 +103,30 @@ http {
 
 	    }
 
-	     location / {
+	location / {
             proxy_pass http://csghub_portal:3000;
             proxy_set_header X-Forwarded-Proto $scheme;
             proxy_set_header X-Forwarded-Host $server_name;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header Host $host;
+        }
+
+	location /api/ {
+            proxy_pass http://csghub_server:8080/api/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $server_name;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
+        location /hf/ {
+            proxy_pass http://csghub_server:8080/hf/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $server_name;
+            proxy_set_header X-Forwarded-Proto $scheme;
         }
 
 	     # used for git operations


### PR DESCRIPTION
为csghub server增加/api和/hf的路由规则