### PR TITLE
Generate git token for user after CSGHub user syncing

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -140,6 +140,13 @@ class User < ApplicationRecord
       raise StarhubError, res.body unless res.success?
       starhub_synced!
     end
+
+    if starhub_synced? && git_token.blank?
+      random_name = SecureRandom.uuid
+      res_body = Starhub.api.generate_git_token(name, random_name)
+      res_json = JSON.parse(res_body)
+      self.update_columns(git_token_name: res_json["data"]["name"], git_token: res_json["data"]["token"])
+    end
   end
 
   def as_json options = nil


### PR DESCRIPTION
1. 在用户完成到后台的同步之后，如果缺失 git token，我们就生成 git token