### PR TITLE
Fix bug: one Starhub API instance for all request

### DIFF
--- a/app/services/starhub.rb
+++ b/app/services/starhub.rb
@@ -1,5 +1,5 @@
 module Starhub
   def self.api user_ip = ""
-    @api ||= Starhub::Api.new user_ip
+    Starhub::Api.new user_ip
   end
 end


### PR DESCRIPTION
在同步用户 ip 的时候，我们初始化后台接口不能只生成一个 api instance