### PR TITLE
fix all-in-one deploy yml for new release

### DIFF
--- a/all-in-one-CN.yml
+++ b/all-in-one-CN.yml
@@ -28,8 +28,6 @@ services:
     healthcheck:
       test: pg_isready -U postgres -h 127.0.0.1
       interval: 5s
-    volumes:
-      - pgdata:/var/lib/postgresql/data
 
   csghub_portal:
     image: registry.cn-beijing.aliyuncs.com/opencsg_public/csghub_portal:latest
@@ -89,6 +87,10 @@ services:
       STARHUB_SERVER_S3_ENDPOINT: minio:9000 # used to generate download links for lfs files
       STARHUB_SERVER_S3_BUCKET: opencsg-server-lfs
       STARHUB_SERVER_S3_REGION: cn-beijing
+      STARHUB_SERVER_MIRRORSERVER_TYPE: gitea
+      STARHUB_SERVER_MIRRORSERVER_HOST: http://${SERVER_DOMAIN}/gitserver
+      STARHUB_SERVER_MIRRORSERVER_USERNAME: root
+      STARHUB_SERVER_MIRRORSERVER_PASSWORD: password123
     ports:
       - "8080:8080"
     restart: always
@@ -164,6 +166,4 @@ networks:
 
 volumes:
   minio_data:
-    driver: local
-  pgdata:
     driver: local

--- a/all-in-one.yml
+++ b/all-in-one.yml
@@ -28,8 +28,6 @@ services:
     healthcheck:
       test: pg_isready -U postgres -h 127.0.0.1
       interval: 5s
-    volumes:
-      - pgdata:/var/lib/postgresql/data
 
   csghub_portal:
     image: opencsg/csghub-portal:latest
@@ -89,6 +87,10 @@ services:
       STARHUB_SERVER_S3_ENDPOINT: minio:9000 # used to generate download links for lfs files
       STARHUB_SERVER_S3_BUCKET: opencsg-server-lfs
       STARHUB_SERVER_S3_REGION: cn-beijing
+      STARHUB_SERVER_MIRRORSERVER_TYPE: gitea
+      STARHUB_SERVER_MIRRORSERVER_HOST: http://${SERVER_DOMAIN}/gitserver
+      STARHUB_SERVER_MIRRORSERVER_USERNAME: root
+      STARHUB_SERVER_MIRRORSERVER_PASSWORD: password123
     ports:
       - "8080:8080"
     restart: always
@@ -164,6 +166,4 @@ networks:
 
 volumes:
   minio_data:
-    driver: local
-  pgdata:
     driver: local


### PR DESCRIPTION
1. CSGHub v0.6.0版本release后，修复all-in-one一键部署脚本存在的问题（starhub server启动失败）
2. 优化一键启动部署脚本：移除postgres的volume数据卷，确保gitea不会由于数据不一致启动失败