### PR TITLE
Fix bug of fetching endpoint billing detail

### DIFF
--- a/app/javascript/components/shared/BillingDetail.vue
+++ b/app/javascript/components/shared/BillingDetail.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script setup>
-  import { ref, inject, onMounted, computed } from 'vue'
+  import { ref, inject, computed, watch } from 'vue'
   import { ElMessage } from 'element-plus'
   import jwtFetch from '../../packs/jwtFetch'
   import { useCookies } from 'vue3-cookies'
@@ -137,6 +137,14 @@
         tempScene = 10
     }
     return tempScene
+  })
+
+  // props instanceName is from Endpoint Detail async data
+  // so we need to watch it here
+  watch(() => props.instanceName, (newVal, oldVal) => {
+    if (newVal !== oldVal) {
+      fetchDetails()
+    }
   })
 
   const disabledDate = (date) => {
@@ -196,10 +204,6 @@
       totalBillings.value = data.total
     }
   }
-
-  onMounted(() => {
-    fetchDetails()
-  })
 </script>
 
 <style scoped lang="less">


### PR DESCRIPTION
It won't get the instance name for the first loading