### PR TITLE
限定项目列表页repocard为双列布局

### DIFF
--- a/app/javascript/components/shared/RepoCards.vue
+++ b/app/javascript/components/shared/RepoCards.vue
@@ -103,7 +103,7 @@
       </div>
       <div
         v-else
-        class="xl:flex-col xl:w-full flex flex-wrap justify-between gap-x-[16px] gap-y-[16px] mb-4 mt-[16px]"
+        class="grid grid-cols-2 xl:flex-col xl:w-full flex flex-wrap justify-between gap-x-[16px] gap-y-[16px] mb-4 mt-[16px]"
       >
         <repo-item
           v-for="repo in reposData"


### PR DESCRIPTION
当前发布版本上没有对repo列表页中的repocard做双列约束，导致行中内容为单时卡片被拉伸为适应容器宽度

<img width="1436" alt="截屏2024-08-15 14 08 17" src="https://github.com/user-attachments/assets/a036e925-5ad2-4a68-a858-5a40d2a124d3">

加上限定后在首页出现单数行时也能够保持对应的卡片宽度

<img width="1427" alt="截屏2024-08-15 14 09 40" src="https://github.com/user-attachments/assets/cc26b80c-c02a-410e-bbfa-21f35091bea4">
