### PR TITLE
change table header name in billing page

### DIFF
--- a/config/locales/en_js/billing.js
+++ b/config/locales/en_js/billing.js
@@ -4,7 +4,7 @@ export const billing = {
   inference: 'Inference Instances',
   instanceID: 'Instance ID',
   createTime: 'Creation Time',
-  usageTime: 'Usage Duration(m)',
+  usageTime: 'Total Duration(m)',
   cost: 'Cost(yuan)',
   status: 'Status',
   details: 'Details',

--- a/config/locales/zh_js/billing.js
+++ b/config/locales/zh_js/billing.js
@@ -4,7 +4,7 @@ export const billing = {
   inference: '推理实例',
   instanceID: '实例id',
   createTime: '创建时间',
-  usageTime: '使用时长(分)',
+  usageTime: '总时长(分)',
   cost: '费用(元)',
   status: '状态',
   details: '明细',


### PR DESCRIPTION
## 问题描述
计费页面表格中使用时长会给用户造成每日使用时长的错觉，但实际上这里的数据代表的是创建以来总计使用时长。

## 优化建议
将 `使用时长` 修改为 `总时长`

| before | after |
| -- | -- |
|   ![image](https://github.com/user-attachments/assets/88f3e38e-e517-4ad2-9c46-2fa33e46c3ed) |  ![image](https://github.com/user-attachments/assets/88f3e38e-e517-4ad2-9c46-2fa33e46c3ed)  |