### PR TITLE
style(markdown): lighten copy button hover background color

### DIFF
--- a/frontend/src/components/shared/viewers/MarkdownViewer.vue
+++ b/frontend/src/components/shared/viewers/MarkdownViewer.vue
@@ -45,7 +45,7 @@
 
       const copyButtonFragment = `
         <clipboard-copy value="${escapeHtml(str)}"
-                        class="copy-button p-1 h-fit hidden group-hover:block hover:bg-gray-500 rounded-sm cursor-pointer"
+                        class="copy-button p-1 h-fit hidden group-hover:block hover:bg-gray-100 rounded-sm cursor-pointer"
         >${copyIcon}</clipboard-copy>`
 
       if (lang && hljs.getLanguage(lang)) {


### PR DESCRIPTION
**What this PR does**:
style(markdown): lighten copy button hover background color

| before | after |
| -- | -- |
|  <img width="775" alt="截屏2024-11-06 14 58 08" src="https://github.com/user-attachments/assets/eab1f203-e0f2-408a-9cd2-26ac61a4a08e"> |  <img width="793" alt="截屏2024-11-06 14 59 30" src="https://github.com/user-attachments/assets/510e0c62-0e2b-462d-a8c6-780cfef79f4e">  |

**Which issue(s) this PR fixes**:

<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

This Merge Request updates the style of the copy button in the MarkdownViewer component by lightening its hover background color. The change aims to improve the user interface by making the hover effect more subtle and visually appealing.

Key updates:
1. Modified the hover background color of the copy button from a darker shade (`bg-gray-500`) to a lighter shade (`bg-gray-100`).

<!-- @codegpt description end -->