### PR TITLE
style(tailwind): convert fontSize values from px to rem

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -73,17 +73,17 @@ export default {
     },
 
     fontSize: {
-      'xs': ['12px', '18px'],
-      'sm': ['14px', '22px'],
-      'md': ['16px', '24px'],
-      'lg': ['18px', '28px'],
-      'xl': ['20px', '30px'],
-      '2xl': ['24px', '32px'],
-      '3xl': ['30px', '38px'],
-      '4xl': ['36px', '44px'],
-      '5xl': ['48px', '60px'],  
-      '6xl': ['60px', '72px'],
-      '7xl': ['72px', '90px'],
+      'xs': ['0.75rem', '1.125rem'],    // 12px, 18px
+      'sm': ['0.875rem', '1.375rem'],   // 14px, 22px
+      'md': ['1rem', '1.5rem'],         // 16px, 24px
+      'lg': ['1.125rem', '1.75rem'],    // 18px, 28px
+      'xl': ['1.25rem', '1.875rem'],    // 20px, 30px
+      '2xl': ['1.5rem', '2rem'],        // 24px, 32px
+      '3xl': ['1.875rem', '2.375rem'],  // 30px, 38px
+      '4xl': ['2.25rem', '2.75rem'],    // 36px, 44px
+      '5xl': ['3rem', '3.75rem'],       // 48px, 60px
+      '6xl': ['3.75rem', '4.5rem'],     // 60px, 72px
+      '7xl': ['4.5rem', '5.625rem'],    // 72px, 90px
     },
 
     fontWeight: {


### PR DESCRIPTION
**What this PR does**:
 convert fontSize values from px to rem
**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

This Merge Request focuses on enhancing the styling approach within a project by converting fontSize values from pixels (px) to rem units in the Tailwind CSS configuration. This change aims to improve scalability and maintainability of font sizes across different screen sizes and resolutions.

Key updates:
1. Converted fontSize values for classes 'xs' to '7xl' from pixels to rem units in `tailwind.config.js`, ensuring a more responsive and accessible design.

<!-- @codegpt description end -->