### PR TITLE
Remove serverless api(model experence)

### DIFF
--- a/frontend/src/components/shared/RepoSummary.vue
+++ b/frontend/src/components/shared/RepoSummary.vue
@@ -16,12 +16,6 @@
         <div class="text-gray-700 text-base font-semibold leading-6 mt-1 md:pl-0">{{ downloadCount }}</div>
       </div>
 
-      <TestEndpoint
-        v-if="widgetType === 'generation' && endpoint?.status === 'Running'"
-        :appEndpoint="appEndpoint"
-        :modelId="namespacePath"
-      />
-
       <SpaceRelationsCard v-if="relations['spaces'] && relations['spaces'].length !== 0"
                           :namespacePath="namespacePath"
                           :spaces="relations['spaces']"
@@ -59,7 +53,6 @@
   import CodeRelationsCard from '../codes/CodeRelationsCard.vue';
   import DatasetRelationsCard from '../datasets/DatasetRelationsCard.vue';
   import ModelRelationsCard from '../models/ModelRelationsCard.vue';
-  import TestEndpoint from '../endpoints/playground/TestEndpoint.vue'
   import useFetchApi from '../../packs/useFetchApi'
   import resolveContent from '../../packs/resolveContent'
 
@@ -117,7 +110,7 @@
         type: 'warning'
       })
     } else {
-      datasetInfo.value = data.value.data.dataset_info 
+      datasetInfo.value = data.value.data.dataset_info
     }
   }
 
@@ -128,12 +121,6 @@
       relations.value = data.value.data
     }
   }
-
-  const appEndpoint = computed(() => {
-    if (!endpoint.value) return ''
-
-    return `https://${endpoint.value.proxy_endpoint}`
-  })
 
   const fetchEndpoint = async () => {
     const url = `/models/${props.namespacePath}/serverless`


### PR DESCRIPTION
**What this PR does**:

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR removes the serverless API model experience from the frontend component `RepoSummary.vue`. Key updates include:
1. Deleted the `TestEndpoint` component usage, which was conditionally rendered for 'generation' widget types with a 'Running' status.
2. Removed the import statement for `TestEndpoint.vue`, indicating the component is no longer used in this file.
3. Minor adjustment to remove trailing whitespace in the assignment of `datasetInfo.value`.
4. Eliminated the computed property `appEndpoint`, which constructed an endpoint URL, suggesting a move away from dynamically generating this URL within the component.

<!-- @codegpt description end -->