### PR TITLE
Enable browser cache for assets

### DIFF
--- a/internal/middleware/cache_control.go
+++ b/internal/middleware/cache_control.go
@@ -1,0 +1,15 @@
+package middleware
+
+import (
+	"strings"
+
+	"github.com/gin-gonic/gin"
+)
+
+func (a *MiddlewareImpl) CacheControlMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if strings.HasPrefix(c.Request.URL.Path, "/assets/") {
+			c.Header("Cache-Control", "public, max-age=2592000")
+		}
+	}
+}

--- a/internal/middleware/cache_control.go
+++ b/internal/middleware/cache_control.go
@@ -11,5 +11,6 @@ func (a *MiddlewareImpl) CacheControlMiddleware() gin.HandlerFunc {
 		if strings.HasPrefix(c.Request.URL.Path, "/assets/") {
 			c.Header("Cache-Control", "public, max-age=2592000")
 		}
+		c.Next()
 	}
 }

--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -11,6 +11,7 @@ type Middleware interface {
 	CheckCurrentUser() gin.HandlerFunc
 	AuthenticateAdminUser() gin.HandlerFunc
 	Log() gin.HandlerFunc
+	CacheControlMiddleware() gin.HandlerFunc
 }
 
 type MiddlewareImpl struct {

--- a/internal/routes/router.go
+++ b/internal/routes/router.go
@@ -67,6 +67,7 @@ func Initialize(svcCtx *svc.ServiceContext) (*gin.Engine, error) {
 		c.AbortWithStatus(http.StatusInternalServerError)
 	}))
 	g.Use(middleware.Instance.AuthMiddleware(csghubServer))
+	g.Use(middleware.Instance.CacheControlMiddleware())
 	// This will track all request to portal go server
 	g.Use(middleware.Instance.Log())
 


### PR DESCRIPTION
**What this PR does**:

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

This Merge Request introduces browser caching for assets. It adds a new middleware function, `CacheControlMiddleware`, to set cache control headers for asset requests, specifying a max-age of 2592000 seconds (30 days). This function is integrated into the middleware stack, ensuring that requests to the `/assets/` path have appropriate caching headers. Key updates include:
1. Creation of `CacheControlMiddleware` in `cache_control.go` to add cache control headers for asset requests.
2. Addition of `CacheControlMiddleware` to the `Middleware` interface in `middleware.go`.
3. Integration of `CacheControlMiddleware` into the application's middleware stack in `router.go`.

<!-- @codegpt description end -->