### PR TITLE
Bug fix: handle no active broadcast case

### DIFF
--- a/frontend/src/components/navbar/Broadcast.vue
+++ b/frontend/src/components/navbar/Broadcast.vue
@@ -60,7 +60,7 @@
     } else {
       showBanner.value.initialized = false
       showBanner.value.show = false
-      ElMessage.warning(error.value.msg)
+      console.log(error.value?.msg || "no active broadcast")
     }
   }
 


### PR DESCRIPTION
**What this PR does**:
Fix the bug of message alert when there's no active broadcast

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The Merge Request addresses a bug by modifying the behavior when no active broadcast is detected. Instead of displaying a warning message to the user, it now logs the error message or a default message "no active broadcast" to the console. This change ensures that the application handles cases of no active broadcasts more gracefully, avoiding potential user confusion.

Key updates:
1. Replaced user-facing warning with console log for no active broadcast scenario.
2. Ensured graceful handling of missing active broadcasts by providing a default log message.

<!-- @codegpt description end -->