### PR TITLE
Repo image path bug fix

### DIFF
--- a/frontend/src/packs/resolveContent.js
+++ b/frontend/src/packs/resolveContent.js
@@ -4,7 +4,7 @@ const relativePathToResolvePath = (repoType, content, namespacePath, currentBran
   if (!content) return content
 
   // const prefix = `/${repoType}/${namespacePath}/resolve/${currentBranch}/`
-  const prefix = currentFilePath
+  const prefix = currentFilePath.replace('/blob/', '/resolve/')
 
   // Handle markdown format image
   content = content.replace(

--- a/frontend/src/packs/resolveContent.js
+++ b/frontend/src/packs/resolveContent.js
@@ -1,9 +1,10 @@
 import { atob_utf8 } from './utils'
 
-const relativePathToResolvePath = (repoType, content, namespacePath, currentBranch) => {
+const relativePathToResolvePath = (repoType, content, namespacePath, currentBranch, currentFilePath) => {
   if (!content) return content
 
-  const prefix = `/${repoType}/${namespacePath}/resolve/${currentBranch}/`
+  // const prefix = `/${repoType}/${namespacePath}/resolve/${currentBranch}/`
+  const prefix = currentFilePath
 
   // Handle markdown format image
   content = content.replace(
@@ -33,6 +34,10 @@ const resolveContent = (repoType, encodedContent, namespacePath, currentBranch) 
   const requestUrl = new URL(window.location.href)
   const fileExtension = requestUrl.pathname.split('.').pop()
 
+  const pathname = requestUrl.pathname
+  const lastSlashIndex = pathname.lastIndexOf('/')
+  const pathWithoutFilename = pathname.substring(0, lastSlashIndex + 1)
+
   let content
 
   if (['jpg', 'png', 'jpeg', 'gif', 'svg'].includes(fileExtension)) {
@@ -44,7 +49,8 @@ const resolveContent = (repoType, encodedContent, namespacePath, currentBranch) 
         repoType,
         parsedBlobContent,
         namespacePath,
-        currentBranch
+        currentBranch,
+        pathWithoutFilename
       )
     } catch (error) {
       console.log(error)

--- a/frontend/src/packs/resolveContent.js
+++ b/frontend/src/packs/resolveContent.js
@@ -1,10 +1,19 @@
 import { atob_utf8 } from './utils'
 
-const relativePathToResolvePath = (repoType, content, namespacePath, currentBranch, currentFilePath) => {
+const relativePathToResolvePath = (repoType, content, namespacePath, currentBranch, requestPath) => {
   if (!content) return content
 
-  // const prefix = `/${repoType}/${namespacePath}/resolve/${currentBranch}/`
-  const prefix = currentFilePath.replace('/blob/', '/resolve/')
+  const repoBasePath = `/${repoType}/${namespacePath}`
+
+  let prefix = `/${repoType}/${namespacePath}/resolve/${currentBranch}/`
+
+  // requestPath === repoBasePath means accessing repo summary page
+  // requestPath !== repoBasePath means accessing a file
+  if (requestPath !== repoBasePath) {
+    const lastSlashIndex = requestPath.lastIndexOf('/')
+    const pathWithoutFilename = requestPath.substring(0, lastSlashIndex + 1)
+    prefix = pathWithoutFilename.replace('/blob/', '/resolve/')
+  }
 
   // Handle markdown format image
   content = content.replace(
@@ -35,8 +44,6 @@ const resolveContent = (repoType, encodedContent, namespacePath, currentBranch) 
   const fileExtension = requestUrl.pathname.split('.').pop()
 
   const pathname = requestUrl.pathname
-  const lastSlashIndex = pathname.lastIndexOf('/')
-  const pathWithoutFilename = pathname.substring(0, lastSlashIndex + 1)
 
   let content
 
@@ -50,7 +57,7 @@ const resolveContent = (repoType, encodedContent, namespacePath, currentBranch) 
         parsedBlobContent,
         namespacePath,
         currentBranch,
-        pathWithoutFilename
+        pathname
       )
     } catch (error) {
       console.log(error)


### PR DESCRIPTION
**What this PR does**:

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

This Merge Request addresses a bug related to the repository image path resolution. It modifies the `relativePathToResolvePath` function to include a new parameter, `requestPath`, allowing for better handling of paths when accessing files versus the repository summary page. Key updates include:

1. Added `requestPath` parameter to the `relativePathToResolvePath` function.
2. Enhanced logic to differentiate between accessing the repo summary and specific files.
3. Updated the `resolveContent` function to pass the current pathname for improved path resolution.

This fix improves the accuracy of image path resolutions in the frontend application.

<!-- @codegpt description end -->