### PR TITLE
fix(RepoCards): adjust spacing and styles

### DIFF
--- a/frontend/src/components/shared/RepoCards.vue
+++ b/frontend/src/components/shared/RepoCards.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex gap-[24px] page-responsive-width m-auto min-h-[calc(100vh-153px)] md:min-h-0 md:px-5">
+    class="flex gap-6 page-responsive-width m-auto min-h-[calc(100vh-153px)] md:min-h-0 md:px-5">
     <div
       v-if="repoType !== 'space'"
       class="w-[30%] min-w-[360px] border-r border-gray-200 pr-6 md:hidden">
@@ -10,9 +10,9 @@
         @resetTags="resetTags"
         :repoType="repoType" />
     </div>
-    <div class="pt-[32px] w-full">
+    <div class="pt-8 w-full">
       <div
-        :class="`flex ${repoType === 'model' ? 'flex-col' : 'xl:flex-col'} gap-3 justify-between ${
+        :class="`flex flex-wrap justify-between items-center gap-2 ${
           repoType === 'space' ? 'xl:pl-[20px] md:pl-0' : ''
         }`">
         <h3 class="text-lg font-normal text-gray-900 flex items-center gap-2">
@@ -38,12 +38,12 @@
             height="18" /> -->
           <span class="capitalize">
             {{ $t(`${repoType}s.title`) }}
-            <span class="text-gray-400 text-md italic">
+            <span class="text-gray-600 text-md font-normal">
               {{ totalRepos }}
             </span>
           </span>
         </h3>
-        <div class="flex flex-wrap gap-2">
+        <div class="md:w-auto flex flex-wrap gap-2">
           <el-select
             v-if="onPremise === 'true'"
             v-model="sourceSelection"
@@ -81,7 +81,7 @@
           </el-select>
           <ElInput
             v-model="nameFilterInput"
-            class="!w-[320px] xl:!w-full"
+            class="w-fit"
             :placeholder="$t(`${repoType}s.placeholder`)"
             :prefix-icon="Search"
             @change="filterChange" />


### PR DESCRIPTION
**What this PR does**:

Arrange the title and filter components horizontally, and switch to vertical arrangement when there is insufficient space. Make the selection component’s width adjust automatically within the container.

- Update gap from 24px to 6
- Change padding-top from 32px to 8
- Modify text color from gray-400 to gray-600
- Set ElInput width to fit instead of fixed

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes  gitlab 435

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR titled 'fix(RepoCards): adjust spacing and styles' primarily focuses on adjusting the styling and spacing in the 'RepoCards.vue' file. Key updates include:
1. The gap has been reduced from 24px to 6px.
2. The padding-top has been changed from 32px to 8px.
3. The text color has been modified from gray-400 to gray-600.
4. The ElInput width has been set to fit instead of being fixed.
These changes are aimed at fixing issue number 435 on GitLab.

<!-- @codegpt description end -->