### PR TITLE
Csghub  add models serverless filter

### DIFF
--- a/frontend/src/components/shared/RepoCards.vue
+++ b/frontend/src/components/shared/RepoCards.vue
@@ -252,7 +252,7 @@
     }
 
     if (filterSelection.value === 'serverless') {
-      url = url + `&tag_category=runtime_framework&tag_name=serverless`
+      url = url + `&list_serverless=true`
     }
 
     for (let [category, tags] of Object.entries(activeTags.value)) {

--- a/frontend/src/components/shared/RepoCards.vue
+++ b/frontend/src/components/shared/RepoCards.vue
@@ -191,6 +191,10 @@
       value: 'evaluation',
       label: t('models.index.evaluationFilter')
     },
+    {
+      value: 'serverless',
+      label: t('models.index.serverlessFilter')
+    }
   ]
 
   const sourceOptions = [
@@ -245,6 +249,10 @@
 
     if (filterSelection.value === 'evaluation') {
       url = url + `&tag_category=runtime_framework&tag_name=opencompass`
+    }
+
+    if (filterSelection.value === 'serverless') {
+      url = url + `&tag_category=runtime_framework&tag_name=serverless`
     }
 
     for (let [category, tags] of Object.entries(activeTags.value)) {

--- a/frontend/src/locales/en_js/models.js
+++ b/frontend/src/locales/en_js/models.js
@@ -20,7 +20,8 @@ export const models = {
     allFilter: "all models",
     inferenceFilter: "support inference",
     finetuneFilter: "support finetune",
-    evaluationFilter: "support evaluation"
+    evaluationFilter: "support evaluation",
+    serverlessFilter: "Serverless API"
   },
   newModel: {
     title: "Create a new model repository",

--- a/frontend/src/locales/zh_js/models.js
+++ b/frontend/src/locales/zh_js/models.js
@@ -18,7 +18,8 @@ export const models = {
     allFilter: "所有模型",
     inferenceFilter: "支持模型推理",
     finetuneFilter: "支持模型微调",
-    evaluationFilter: "支持模型评测"
+    evaluationFilter: "支持模型评测",
+    serverlessFilter: "公共推理实例"
   },
   newModel: {
     title: "新建模型仓库",


### PR DESCRIPTION
**What this PR does**:

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR introduces a new 'serverless' filter to the model repository in the Csghub application. The main changes include:
1. Addition of a new filter option 'serverless' in the RepoCards.vue file. This filter modifies the URL to list serverless models when selected.
2. Update of the English and Chinese locale files (en_js/models.js and zh_js/models.js) to include the 'serverless' filter label. This ensures the filter is properly labeled in both languages.

<!-- @codegpt description end -->