### PR TITLE
fix(repoHeader): update source condition

### DIFF
--- a/frontend/src/components/shared/RepoHeader.vue
+++ b/frontend/src/components/shared/RepoHeader.vue
@@ -113,7 +113,7 @@
         nickname.trim() === '' ? name : nickname
       }}</span>
       <RepoHeaderSourceIcon
-        v-if="repoDetailStore.source"
+        v-if="repoDetailStore.source !== 'local'"
         :repoType="repoType"
         :source="repoSource"
         :sourcePath="repoSourcePath"


### PR DESCRIPTION
- Exclude 'local' from source check
- Ensure correct rendering of RepoHeaderSourceIcon

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR titled 'fix(repoHeader): update source condition' primarily addresses a bug in the 'RepoHeader.vue' file. The key change is the modification of the condition for rendering the 'RepoHeaderSourceIcon'. Previously, the icon was displayed if 'repoDetailStore.source' existed. Now, it will be displayed only if 'repoDetailStore.source' is not equal to 'local'. This change ensures the correct rendering of the 'RepoHeaderSourceIcon'.

<!-- @codegpt description end -->