### PR TITLE
feat(RepoHeader): update source display logic

### DIFF
--- a/frontend/src/components/__tests__/shared/RepoHeader.spec.js
+++ b/frontend/src/components/__tests__/shared/RepoHeader.spec.js
@@ -265,24 +265,4 @@ describe('RepoHeader Source Display', () => {
       wrapper.findComponent({ name: 'RepoHeaderSourceIcon' }).props('source')
     ).toBe('HuggingFace')
   })
-
-  it('displays OpenCSG source with cleaned path', async () => {
-    mockRepoDetailStore.hfPath = null
-    mockRepoDetailStore.csgPath = 'cleaned_path'
-
-    const wrapper = createWrapper()
-    const sourceIcon = wrapper.findComponent({ name: 'RepoHeaderSourceIcon' })
-
-    expect(sourceIcon.props('source')).toBe('OpenCSG')
-    expect(sourceIcon.props('sourcePath')).toBe('cleaned_path')
-  })
-
-  it('handles CSG_ prefixed path correctly', async () => {
-    mockRepoDetailStore.hfPath = null
-    mockRepoDetailStore.msPath = null
-    mockRepoDetailStore.csgPath = null
-
-    const wrapper = createWrapper()
-    expect(wrapper.vm.repoSourcePath).toBe('123')
-  })
 })

--- a/frontend/src/components/shared/RepoHeader.vue
+++ b/frontend/src/components/shared/RepoHeader.vue
@@ -18,7 +18,7 @@
         nickname.trim() === '' ? name : nickname
       }}</span>
       <RepoHeaderSourceIcon
-        v-if="repoDetailStore.source !== 'local'"
+        v-if="!!repoSource"
         :repoType="repoType"
         :source="repoSource"
         :sourcePath="repoSourcePath"
@@ -113,7 +113,7 @@
         nickname.trim() === '' ? name : nickname
       }}</span>
       <RepoHeaderSourceIcon
-        v-if="repoDetailStore.source !== 'local'"
+        v-if="!!repoSource"
         :repoType="repoType"
         :source="repoSource"
         :sourcePath="repoSourcePath"
@@ -335,7 +335,7 @@
     } else if (repoDetailStore.msPath) {
       return 'ModelScope'
     } else {
-      return 'OpenCSG'
+      return ''
     }
   })
 


### PR DESCRIPTION
- Change condition for displaying source icon
- Remove OpenCSG source handling
- Return empty string for undefined sources

**What this PR does**:

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes #

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- @codegpt description start -->


### MR Summary:
*The summary is added by @codegpt.*

The MR titled 'feat(RepoHeader): update source display logic' primarily updates the logic for displaying source icons in the RepoHeader component. Key changes include:
1. The condition for displaying the source icon has been modified. It now checks for the existence of 'repoSource' instead of excluding 'local' sources.
2. The handling of 'OpenCSG' sources has been removed. If none of the other sources (HuggingFace, ModelScope) are defined, an empty string is returned instead of 'OpenCSG'.
3. Corresponding test cases for 'OpenCSG' source display in 'RepoHeader.spec.js' have been removed.

<!-- @codegpt description end -->