### PR TITLE
fix relative path wrong in pge edition

### DIFF
--- a/frontend/src/components/shared/FileList.vue
+++ b/frontend/src/components/shared/FileList.vue
@@ -212,7 +212,7 @@
   const goToNewFile = () => {
     setRepoTab({
       actionName: 'new_file',
-      lastPath: ''
+      lastPath: currentPath.value.length > 0 ? '/' + currentPath.value : ''
     })
   }
 

--- a/frontend/src/components/shared/NewFile.vue
+++ b/frontend/src/components/shared/NewFile.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex flex-col gap-4 my-[30px] md:px-5">
     <div class="flex items-center gap-[10px]">
-      <div class="whitespace-nowrap">{{ repoName }}</div>
+      <div class="whitespace-nowrap">{{ repoName + repoTab.lastPath }}</div>
       <div class="text-gray-500">/</div>
       <el-input
         v-model="fileName"
@@ -117,7 +117,7 @@
   const createFile = async () => {
     submiting.value = true
     // TODO: main branch for now; should support different branches
-    const createFileEndpoint = `/${apiPrefixPath}/${props.namespacePath}/raw/${fileName.value}`
+    const createFileEndpoint = `/${apiPrefixPath}/${props.namespacePath}/raw${repoTab.lastPath}/${fileName.value}`
     const bodyData = {
       content: btoa_utf8(codeContent.value),
       message: buildCommitMessage(),
@@ -144,7 +144,7 @@
     // window.location.href = `/${prefixPath}/${props.namespacePath}/blob/${props.currentBranch}/${fileName.value}`
     setRepoTab({
       actionName: 'blob',
-      lastPath: fileName.value
+      lastPath: repoTab.lastPath + '/' + fileName.value
     })
   }
 


### PR DESCRIPTION
**What this PR does**:
The main fix addresses the issue where editing repository files on the page could not be applied to specified paths. It now enables creating new files under designated paths.

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes # gitlab-809

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
