### PR TITLE
show dataset in evaluation detail page

### DIFF
--- a/frontend/src/components/evaluations/NewEvaluation.vue
+++ b/frontend/src/components/evaluations/NewEvaluation.vue
@@ -168,6 +168,7 @@
                 "
                 size="large"
                 multiple
+                class="ignore-height-select"
             >
               <el-option
                 v-for="item in models"
@@ -763,6 +764,10 @@
 
   :deep(.el-select) {
     height: 40px;
+  }
+
+  :deep(.ignore-height-select.el-select) {
+    height: auto !important;
   }
 
   :deep(.ignore-height-select.el-select) {

--- a/frontend/src/locales/en_js/evaluation.js
+++ b/frontend/src/locales/en_js/evaluation.js
@@ -44,7 +44,8 @@ export const evaluation = {
     download: "Download Results",
     evaluationFailed: "Evaluation Failed",
     return: "Return",
-    recreate: "Recreate"
+    recreate: "Recreate",
+    invalidDataset: "The dataset has been deleted or is invalid"
   },
   list: {
     title: "Model Evaluation",

--- a/frontend/src/locales/zh_hant_js/evaluation.js
+++ b/frontend/src/locales/zh_hant_js/evaluation.js
@@ -44,7 +44,8 @@ export const evaluation = {
     download: "下載評測結果",
     evaluationFailed: "評測失敗",
     return: "返回",
-    recreate: "重新創建"
+    recreate: "重新創建",
+    invalidDataset: "數據集已刪除或失效"
   },
   list: {
     title: "模型評測",

--- a/frontend/src/locales/zh_js/evaluation.js
+++ b/frontend/src/locales/zh_js/evaluation.js
@@ -44,7 +44,8 @@ export const evaluation = {
     download: "下载评测结果",
     evaluationFailed: "评测失败",
     return: "返回",
-    recreate: "重新创建"
+    recreate: "重新创建",
+    invalidDataset: "数据集已删除或失效"
   },
   list: {
     title: "模型评测",


### PR DESCRIPTION
**What this PR does**:
- Optimize the display of datasets on the model evaluation details page, where deleted datasets are presented in a distinct format.
- Fix the styling disorder issue that occurs when selecting multiple custom datasets during new model evaluation creation.

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes # gitlab-875

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
