### PR TITLE
fix relative path wrong in pge edition while upload file

### DIFF
--- a/frontend/src/components/shared/FileList.vue
+++ b/frontend/src/components/shared/FileList.vue
@@ -212,14 +212,14 @@
   const goToNewFile = () => {
     setRepoTab({
       actionName: 'new_file',
-      lastPath: ''
+      lastPath: currentPath.value && currentPath.value.length > 0 ? '/' + currentPath.value : ''
     })
   }
 
   const goToUploadFile = () => {
     setRepoTab({
       actionName: 'upload_file',
-      lastPath: ''
+      lastPath: currentPath.value && currentPath.value.length > 0 ? '/' + currentPath.value : ''
     })
   }
 


### PR DESCRIPTION
**What this PR does**:
- Fixed: Uploaded files in model/dataset management not saving to designated paths.
- Post-upload redirect now correctly points to the operation completion path.

**Which issue(s) this PR fixes**:
<!--  link to issue number:
optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged
-->
Fixes # gitlab-809

**Type of changes**
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

**Feature/Issue validation/testing**:

Please describe the tests that you ran to verify your changes and relevant result summary. 

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:


**Checklist**:

- [ ] I have added unit/e2e tests that prove your fix is effective or that this feature works.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have reviewed my own code and ensured that it follows the project's style guidelines.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
