### PR TITLE
test(render): add unit tests for CodeHandlerImpl

### DIFF
--- a/internal/handlers/render/codes_test.go
+++ b/internal/handlers/render/codes_test.go
@@ -1,0 +1,105 @@
+package renderHandlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	mockRenderBase "opencsg.com/portal/_mocks/opencsg.com/portal/handlers/render"
+	"opencsg.com/portal/pkg/types"
+)
+
+func TestCodeHandlerImpl_List(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "codes_index", mock.Anything).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	req, _ := http.NewRequest("GET", "/codes", nil)
+	ctx.Request = req
+
+	handler := &CodeHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "codes",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.List(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCodeHandlerImpl_Detail(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "codes_show", mock.MatchedBy(func(data map[string]interface{}) bool {
+			return data["namespace"] == "test-namespace" &&
+				data["codeName"] == "test-code" &&
+				data["actionName"] == "show" &&
+				data["defaultTab"] == "summary"
+		})).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	// Mock route parameters in Gin context
+	ctx.Params = gin.Params{
+		{Key: "namespace", Value: "test-namespace"},
+		{Key: "code_name", Value: "test-code"},
+	}
+
+	req, _ := http.NewRequest("GET", "/codes/test-namespace/test-code", nil)
+	ctx.Request = req
+
+	handler := &CodeHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "codes",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.Detail(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestCodeHandlerImpl_New(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "codes_new", mock.MatchedBy(func(data map[string]interface{}) bool {
+			licenses, ok := data["licenses"].(string)
+			return ok && licenses == DefaultLicensesJSON
+		})).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	req, _ := http.NewRequest("GET", "/codes/new", nil)
+	ctx.Request = req
+
+	handler := &CodeHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "codes",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.New(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}


### PR DESCRIPTION
## Summary of Changes
This PR expands backend test coverage by adding unit tests for `CodeHandlerImpl` under `internal/handlers/render/`.

### Changes:
- **New File**: `internal/handlers/render/codes_test.go`
  - Added route rendering coverage for:
    1. `List` route (`codes_index` template rendering).
    2. `Detail` route (parameter mapping of `namespace` and `code_name` to `codes_show` template).
    3. `New` route (checks context layout and license dictionary injection matching `DefaultLicensesJSON`).

All rendering calls are tested in isolation using Mockery's testifying mocks.