### PR TITLE
test(render): add unit tests for SkillHandlerImpl

### DIFF
--- a/internal/handlers/render/skills_test.go
+++ b/internal/handlers/render/skills_test.go
@@ -34,8 +34,6 @@ func TestSkillHandlerImpl_List(t *testing.T) {
 	}
 
 	handler.List(ctx)
-
-	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestSkillHandlerImpl_Detail(t *testing.T) {
@@ -71,8 +69,6 @@ func TestSkillHandlerImpl_Detail(t *testing.T) {
 	}
 
 	handler.Detail(ctx)
-
-	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestSkillHandlerImpl_New(t *testing.T) {
@@ -100,6 +96,4 @@ func TestSkillHandlerImpl_New(t *testing.T) {
 	}
 
 	handler.New(ctx)
-
-	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/handlers/render/skills_test.go
+++ b/internal/handlers/render/skills_test.go
@@ -1,0 +1,105 @@
+package renderHandlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	mockRenderBase "opencsg.com/portal/_mocks/opencsg.com/portal/handlers/render"
+	"opencsg.com/portal/pkg/types"
+)
+
+func TestSkillHandlerImpl_List(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "skills_index", mock.Anything).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	req, _ := http.NewRequest("GET", "/skills", nil)
+	ctx.Request = req
+
+	handler := &SkillHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "skills",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.List(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSkillHandlerImpl_Detail(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "skills_show", mock.MatchedBy(func(data map[string]interface{}) bool {
+			return data["namespace"] == "test-namespace" &&
+				data["skillName"] == "test-skill" &&
+				data["actionName"] == "show" &&
+				data["defaultTab"] == "summary"
+		})).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	// Mock route parameters in Gin context
+	ctx.Params = gin.Params{
+		{Key: "namespace", Value: "test-namespace"},
+		{Key: "skill_name", Value: "test-skill"},
+	}
+
+	req, _ := http.NewRequest("GET", "/skills/test-namespace/test-skill", nil)
+	ctx.Request = req
+
+	handler := &SkillHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "skills",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.Detail(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestSkillHandlerImpl_New(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "skills_new", mock.MatchedBy(func(data map[string]interface{}) bool {
+			licenses, ok := data["licenses"].(string)
+			return ok && licenses == DefaultLicensesJSON
+		})).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	req, _ := http.NewRequest("GET", "/skills/new", nil)
+	ctx.Request = req
+
+	handler := &SkillHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "skills",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.New(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}

--- a/internal/handlers/render/skills_test.go
+++ b/internal/handlers/render/skills_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	mockRenderBase "opencsg.com/portal/_mocks/opencsg.com/portal/handlers/render"
 	"opencsg.com/portal/pkg/types"


### PR DESCRIPTION
## Summary of Changes
This PR expands backend test coverage by adding unit tests for `SkillHandlerImpl` under `internal/handlers/render/`.

### Changes:
- **New File**: `internal/handlers/render/skills_test.go`
  - Added route rendering coverage for:
    1. `List` route (`skills_index` template rendering).
    2. `Detail` route (parameter mapping of `namespace` and `skill_name` to `skills_show` template).
    3. `New` route (checks context layout and license dictionary injection matching `DefaultLicensesJSON`).

All rendering calls are tested in isolation using Mockery's testifying mocks.