### PR TITLE
test(render): add unit tests for FinetuneHandlerImpl

### DIFF
--- a/internal/handlers/render/finetune_test.go
+++ b/internal/handlers/render/finetune_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	mockRenderBase "opencsg.com/portal/_mocks/opencsg.com/portal/handlers/render"
 	"opencsg.com/portal/pkg/types"
@@ -33,6 +34,8 @@ func TestFinetuneHandlerImpl_List(t *testing.T) {
 	}
 
 	handler.List(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestFinetuneHandlerImpl_Detail(t *testing.T) {
@@ -72,6 +75,8 @@ func TestFinetuneHandlerImpl_Detail(t *testing.T) {
 	}
 
 	handler.Detail(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestFinetuneHandlerImpl_New(t *testing.T) {
@@ -99,4 +104,6 @@ func TestFinetuneHandlerImpl_New(t *testing.T) {
 	}
 
 	handler.New(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
 }

--- a/internal/handlers/render/finetune_test.go
+++ b/internal/handlers/render/finetune_test.go
@@ -1,0 +1,102 @@
+package renderHandlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/mock"
+	mockRenderBase "opencsg.com/portal/_mocks/opencsg.com/portal/handlers/render"
+	"opencsg.com/portal/pkg/types"
+)
+
+func TestFinetuneHandlerImpl_List(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "finetunes_index", mock.Anything).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	req, _ := http.NewRequest("GET", "/finetunes", nil)
+	ctx.Request = req
+
+	handler := &FinetuneHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "finetunes",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.List(ctx)
+}
+
+func TestFinetuneHandlerImpl_Detail(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "finetunes_show", mock.MatchedBy(func(data map[string]interface{}) bool {
+			return data["namespace"] == "test-namespace" &&
+				data["modelName"] == "test-model" &&
+				data["finetuneId"] == "test-finetune-id" &&
+				data["finetuneName"] == "test-finetune-name" &&
+				data["actionName"] == "show" &&
+				data["defaultTab"] == "summary"
+		})).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	// Mock route parameters in Gin context
+	ctx.Params = gin.Params{
+		{Key: "namespace", Value: "test-namespace"},
+		{Key: "model_name", Value: "test-model"},
+		{Key: "finetune_id", Value: "test-finetune-id"},
+		{Key: "finetune_name", Value: "test-finetune-name"},
+	}
+
+	req, _ := http.NewRequest("GET", "/finetunes/test-namespace/test-model/test-finetune-id/test-finetune-name", nil)
+	ctx.Request = req
+
+	handler := &FinetuneHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "finetunes",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.Detail(ctx)
+}
+
+func TestFinetuneHandlerImpl_New(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "finetunes_new", mock.MatchedBy(func(data map[string]interface{}) bool {
+			licenses, ok := data["licenses"].(string)
+			return ok && licenses == DefaultLicensesJSON
+		})).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	req, _ := http.NewRequest("GET", "/finetunes/new", nil)
+	ctx.Request = req
+
+	handler := &FinetuneHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "finetunes",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.New(ctx)
+}


### PR DESCRIPTION
## Summary of Changes
This PR expands backend test coverage by adding unit tests for `FinetuneHandlerImpl` under `internal/handlers/render/`.

### Changes:
- **New File**: `internal/handlers/render/finetune_test.go`
  - Added route rendering coverage for:
    1. `List` route (`finetunes_index` template rendering).
    2. `Detail` route (parameter mapping of `namespace`, `model_name`, `finetune_id`, and `finetune_name` to `finetunes_show` template).
    3. `New` route (checks context layout and license dictionary injection matching `DefaultLicensesJSON`).

All rendering calls are tested in isolation using Mockery's testifying mocks.