### PR TITLE
test(render): add unit tests for EndpointHandlerImpl

### DIFF
--- a/internal/handlers/render/endpoint_test.go
+++ b/internal/handlers/render/endpoint_test.go
@@ -1,0 +1,107 @@
+package renderHandlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	mockRenderBase "opencsg.com/portal/_mocks/opencsg.com/portal/handlers/render"
+	"opencsg.com/portal/pkg/types"
+)
+
+func TestEndpointHandlerImpl_List(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "endpoints_index", mock.Anything).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	req, _ := http.NewRequest("GET", "/endpoints", nil)
+	ctx.Request = req
+
+	handler := &EndpointHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "endpoints",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.List(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestEndpointHandlerImpl_Detail(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "endpoints_show", mock.MatchedBy(func(data map[string]interface{}) bool {
+			return data["namespace"] == "test-namespace" &&
+				data["modelName"] == "test-model" &&
+				data["endpointId"] == "test-endpoint-id" &&
+				data["actionName"] == "show" &&
+				data["defaultTab"] == "summary"
+		})).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	// Mock route parameters in Gin context
+	ctx.Params = gin.Params{
+		{Key: "namespace", Value: "test-namespace"},
+		{Key: "model_name", Value: "test-model"},
+		{Key: "endpoint_id", Value: "test-endpoint-id"},
+	}
+
+	req, _ := http.NewRequest("GET", "/endpoints/test-namespace/test-model/test-endpoint-id", nil)
+	ctx.Request = req
+
+	handler := &EndpointHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "endpoints",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.Detail(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestEndpointHandlerImpl_New(t *testing.T) {
+	mockBase := mockRenderBase.NewMockRenderBase(t)
+
+	mockBase.EXPECT().
+		RenderTemplate(mock.Anything, "endpoints_new", mock.MatchedBy(func(data map[string]interface{}) bool {
+			licenses, ok := data["licenses"].(string)
+			return ok && licenses == DefaultLicensesJSON
+		})).
+		Return()
+
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Set("Config", types.GlobalConfig{})
+
+	req, _ := http.NewRequest("GET", "/endpoints/new", nil)
+	ctx.Request = req
+
+	handler := &EndpointHandlerImpl{
+		BaseHandlerImpl{
+			resourceType:       "endpoints",
+			renderBaseInstance: mockBase,
+		},
+	}
+
+	handler.New(ctx)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}


### PR DESCRIPTION
## Summary of Changes
This PR expands backend test coverage by adding unit tests for `EndpointHandlerImpl` under `internal/handlers/render/`.

### Changes:
- **New File**: `internal/handlers/render/endpoint_test.go`
  - Added route rendering coverage for:
    1. `List` route (`endpoints_index` template rendering).
    2. `Detail` route (parameter mapping of `namespace`, `model_name`, and `endpoint_id` to `endpoints_show` template).
    3. `New` route (checks context layout and license dictionary injection matching `DefaultLicensesJSON`).

All rendering calls are tested in isolation using Mockery's testifying mocks.